### PR TITLE
give redis_lib crates unique names so we dont need to regen the lock file on each compile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clap"
-version = "2.24.0"
+version = "2.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -179,11 +179,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "habitat_builder_dbcache"
+name = "habitat_builder_dbcache_redis"
 version = "0.0.0"
 dependencies = [
  "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "habitat_builder_protocol 0.0.0",
+ "habitat_builder_protocol_redis 0.0.0",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -207,10 +207,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "habitat_builder_protocol"
+name = "habitat_builder_protocol_redis"
 version = "0.0.0"
 dependencies = [
- "habitat_core 0.0.0",
+ "habitat_core_redis 0.0.0",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -223,13 +223,13 @@ name = "habitat_builder_sessionsrv"
 version = "0.0.0"
 dependencies = [
  "bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.24.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_builder_db 0.0.0",
  "habitat_builder_protocol 0.0.0",
  "habitat_core 0.0.0",
  "habitat_net 0.0.0",
- "hyper 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.10.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -242,17 +242,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "habitat_builder_sessionsrv"
+name = "habitat_builder_sessionsrv_redis"
 version = "0.0.0"
 dependencies = [
  "bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.24.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "habitat_builder_dbcache 0.0.0",
- "habitat_builder_protocol 0.0.0",
- "habitat_core 0.0.0",
- "habitat_net 0.0.0",
- "hyper 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "habitat_builder_dbcache_redis 0.0.0",
+ "habitat_builder_protocol_redis 0.0.0",
+ "habitat_core_redis 0.0.0",
+ "habitat_net_redis 0.0.0",
+ "hyper 0.10.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -280,7 +280,7 @@ dependencies = [
  "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sodiumoxide 0.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -290,7 +290,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "habitat_core"
+name = "habitat_core_redis"
 version = "0.0.0"
 dependencies = [
  "errno 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -317,7 +317,7 @@ dependencies = [
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_builder_protocol 0.0.0",
  "habitat_core 0.0.0",
- "hyper 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.10.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-openssl 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -327,20 +327,20 @@ dependencies = [
  "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zmq 0.8.1 (git+https://github.com/erickt/rust-zmq?branch=release/v0.8)",
 ]
 
 [[package]]
-name = "habitat_net"
+name = "habitat_net_redis"
 version = "0.0.0"
 dependencies = [
  "bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "habitat_builder_protocol 0.0.0",
- "hyper 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "habitat_builder_protocol_redis 0.0.0",
+ "hyper 0.10.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -375,15 +375,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hyper"
-version = "0.10.9"
+version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "base64 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -398,7 +398,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.10.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -419,7 +419,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "conduit-mime-types 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "error 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.10.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "modifier 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -737,12 +737,12 @@ version = "0.1.0"
 dependencies = [
  "bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "habitat_builder_dbcache 0.0.0",
- "habitat_builder_protocol 0.0.0",
- "habitat_builder_sessionsrv 0.0.0",
- "habitat_core 0.0.0",
- "habitat_net 0.0.0",
- "hyper 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "habitat_builder_dbcache_redis 0.0.0",
+ "habitat_builder_protocol_redis 0.0.0",
+ "habitat_builder_sessionsrv_redis 0.0.0",
+ "habitat_core_redis 0.0.0",
+ "habitat_net_redis 0.0.0",
+ "hyper 0.10.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1152,7 +1152,7 @@ dependencies = [
 "checksum bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1370e9fc2a6ae53aea8b7a5110edbd08836ed87c88736dfabccade1c2b44bff4"
 "checksum bufstream 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f2f382711e76b9de6c744cc00d0497baba02fb00a787f088c879f01d09468e32"
 "checksum byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c40977b0ee6b9885c9013cd41d9feffdd22deb3bb4dc3a71d901cc7a77de18c8"
-"checksum clap 2.24.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f31c42d0cecb245c1a0bee00ef433eb1bf253897fe472b6a3f4202e9dbbc4b25"
+"checksum clap 2.24.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b7541069be0b8aec41030802abe8b5cdef0490070afaa55418adea93b1e431e0"
 "checksum conduit-mime-types 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "95ca30253581af809925ef68c2641cc140d6183f43e12e0af4992d53768bd7b8"
 "checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
 "checksum env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e3856f1697098606fc6cb97a93de88ca3f3bc35bb878c725920e6e82ecf05e83"
@@ -1166,7 +1166,7 @@ dependencies = [
 "checksum gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0912515a8ff24ba900422ecda800b52f4016a56251922d397c576bf92c690518"
 "checksum hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
 "checksum httparse 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77f756bed9ee3a83ce98774f4155b42a31b787029013f3a7d83eca714e500e21"
-"checksum hyper 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)" = "94da93321c171e26481afeebe8288757b0501901b7c5492648163d8ec4942ec5"
+"checksum hyper 0.10.10 (registry+https://github.com/rust-lang/crates.io-index)" = "36e108e0b1fa2d17491cbaac4bc460dc0956029d10ccf83c913dd0e5db3e7f07"
 "checksum hyper-openssl 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "85a372eb692590b3fe014c196c30f9f52d4c42f58cd49dd94caeee1593c9cc37"
 "checksum idna 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6ac85ec3f80c8e4e99d9325521337e14ec7555c458a14e377d189659a427f375"
 "checksum iron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2440ae846e7a8c7f9b401db8f6e31b4ea5e7d3688b91761337da7e054520c75b"
@@ -1219,7 +1219,7 @@ dependencies = [
 "checksum serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3b46a59dd63931010fdb1d88538513f3279090d88b5c22ef4fe8440cfffcc6e3"
 "checksum serde_derive 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6c06b68790963518008b8ae0152d48be4bbbe77015d2c717f6282eea1824be9a"
 "checksum serde_derive_internals 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "021c338d22c7e30f957a6ab7e388cb6098499dda9fd4ba1661ee074ca7a180d1"
-"checksum serde_json 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1c62115693d0a9ed8c32d1c760f0fdbe7d4b05cb13c135b9b54137ac0d59fccb"
+"checksum serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "48b04779552e92037212c3615370f6bd57a40ebba7f20e554ff9f55e41a69a7b"
 "checksum sha1 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a307a40d5834140e4213a6952483b84e9ad53bdcab918b7335a6e305e505a53c"
 "checksum sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cc30b1e1e8c40c121ca33b86c23308a090d19974ef001b4bf6e61fd1a0fb095c"
 "checksum siphasher 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0df90a788073e8d0235a67e50441d47db7c8ad9debd91cbf43736a2a92d36537"

--- a/src/redis_lib/Cargo.toml
+++ b/src/redis_lib/Cargo.toml
@@ -16,19 +16,19 @@ rustc-serialize = "*"
 time = "*"
 toml = "0.1.29"
 
-[dependencies.habitat_builder_dbcache]
+[dependencies.habitat_builder_dbcache_redis]
 path = "./builder-dbcache"
 
-[dependencies.habitat_builder_protocol]
+[dependencies.habitat_builder_protocol_redis]
 path = "./builder-protocol"
 
-[dependencies.habitat_core]
+[dependencies.habitat_core_redis]
 path = "./core"
 
-[dependencies.habitat_builder_sessionsrv]
+[dependencies.habitat_builder_sessionsrv_redis]
 path = "./builder-sessionsrv"
 
-[dependencies.habitat_net]
+[dependencies.habitat_net_redis]
 path = "./net"
 
 [dependencies.zmq]

--- a/src/redis_lib/builder-dbcache/Cargo.toml
+++ b/src/redis_lib/builder-dbcache/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "habitat_builder_dbcache"
+name = "habitat_builder_dbcache_redis"
 version = "0.0.0"
 authors = ["Adam Jacob <adam@chef.io>", "Jamie Winsor <reset@chef.io>", "Fletcher Nichol <fnichol@chef.io>", "Joshua Timberman <joshua@chef.io>", "Dave Parfitt <dparfitt@chef.io>"]
 description = "Habitat-Builder Database Access Library"
@@ -16,7 +16,7 @@ r2d2_redis = "*"
 rustc-serialize = "*"
 time = "*"
 
-[dependencies.habitat_builder_protocol]
+[dependencies.habitat_builder_protocol_redis]
 path = "../builder-protocol"
 
 [features]

--- a/src/redis_lib/builder-dbcache/src/lib.rs
+++ b/src/redis_lib/builder-dbcache/src/lib.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate habitat_builder_protocol as protocol;
+extern crate habitat_builder_protocol_redis as protocol;
 #[macro_use]
 extern crate log;
 extern crate num_cpus;

--- a/src/redis_lib/builder-protocol/Cargo.toml
+++ b/src/redis_lib/builder-protocol/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "habitat_builder_protocol"
+name = "habitat_builder_protocol_redis"
 version = "0.0.0"
 authors = ["Adam Jacob <adam@chef.io>", "Jamie Winsor <reset@chef.io>", "Fletcher Nichol <fnichol@chef.io>", "Joshua Timberman <joshua@chef.io>", "Dave Parfitt <dparfitt@chef.io>"]
 description = "Habitat-Builder Network Server Protocol"
@@ -11,7 +11,7 @@ redis = "*"
 rustc-serialize = "*"
 time = "*"
 
-[dependencies.habitat_core]
+[dependencies.habitat_core_redis]
 path = "../core"
 
 [build-dependencies]

--- a/src/redis_lib/builder-protocol/src/lib.rs
+++ b/src/redis_lib/builder-protocol/src/lib.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate habitat_core as hab_core;
+extern crate habitat_core_redis as hab_core;
 extern crate protobuf;
 extern crate redis;
 extern crate rustc_serialize;

--- a/src/redis_lib/builder-sessionsrv/Cargo.toml
+++ b/src/redis_lib/builder-sessionsrv/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "habitat_builder_sessionsrv"
+name = "habitat_builder_sessionsrv_redis"
 version = "0.0.0"
 authors = ["Adam Jacob <adam@chef.io>", "Jamie Winsor <reset@chef.io>", "Fletcher Nichol <fnichol@chef.io>", "Joshua Timberman <joshua@chef.io>", "Dave Parfitt <dparfitt@chef.io>"]
 description = "Habitat-Builder Session Server"
@@ -23,16 +23,16 @@ features = [ "suggestions", "color", "unstable" ]
 git = "https://github.com/erickt/rust-zmq.git"
 branch = "release/v0.8"
 
-[dependencies.habitat_core]
+[dependencies.habitat_core_redis]
 path = "../core"
 
-[dependencies.habitat_builder_dbcache]
+[dependencies.habitat_builder_dbcache_redis]
 path = "../builder-dbcache"
 
-[dependencies.habitat_builder_protocol]
+[dependencies.habitat_builder_protocol_redis]
 path = "../builder-protocol"
 
-[dependencies.habitat_net]
+[dependencies.habitat_net_redis]
 path = "../net"
 
 [features]

--- a/src/redis_lib/builder-sessionsrv/src/lib.rs
+++ b/src/redis_lib/builder-sessionsrv/src/lib.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate habitat_builder_dbcache as dbcache;
-extern crate habitat_builder_protocol as protocol;
-extern crate habitat_core as hab_core;
-extern crate habitat_net as hab_net;
+extern crate habitat_builder_dbcache_redis as dbcache;
+extern crate habitat_builder_protocol_redis as protocol;
+extern crate habitat_core_redis as hab_core;
+extern crate habitat_net_redis as hab_net;
 extern crate hyper;
 #[macro_use]
 extern crate log;

--- a/src/redis_lib/core/Cargo.toml
+++ b/src/redis_lib/core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "habitat_core"
+name = "habitat_core_redis"
 version = "0.0.0"
 authors = ["Adam Jacob <adam@chef.io>", "Jamie Winsor <reset@chef.io>", "Fletcher Nichol <fnichol@chef.io>", "Joshua Timberman <joshua@chef.io>", "Dave Parfitt <dparfitt@chef.io>", "Steven Murawski <smurawski@chef.io>"]
 workspace = "../../"

--- a/src/redis_lib/net/Cargo.toml
+++ b/src/redis_lib/net/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "habitat_net"
+name = "habitat_net_redis"
 version = "0.0.0"
 authors = ["Adam Jacob <adam@chef.io>", "Jamie Winsor <reset@chef.io>", "Fletcher Nichol <fnichol@chef.io>", "Joshua Timberman <joshua@chef.io>", "Dave Parfitt <dparfitt@chef.io>"]
 workspace = "../../"
@@ -19,7 +19,7 @@ rustc-serialize = "*"
 time = "*"
 unicase = "*"
 
-[dependencies.habitat_builder_protocol]
+[dependencies.habitat_builder_protocol_redis]
 path = "../builder-protocol"
 
 [dependencies.zmq]

--- a/src/redis_lib/net/src/lib.rs
+++ b/src/redis_lib/net/src/lib.rs
@@ -15,7 +15,7 @@
 #[macro_use]
 extern crate bitflags;
 extern crate fnv;
-extern crate habitat_builder_protocol as protocol;
+extern crate habitat_builder_protocol_redis as protocol;
 #[macro_use]
 extern crate hyper;
 extern crate iron;

--- a/src/redis_lib/src/lib.rs
+++ b/src/redis_lib/src/lib.rs
@@ -1,6 +1,6 @@
-extern crate habitat_builder_sessionsrv as hab_sessionsrv;
-extern crate habitat_builder_protocol as protocol;
-extern crate habitat_builder_dbcache as dbcache;
+extern crate habitat_builder_sessionsrv_redis as hab_sessionsrv;
+extern crate habitat_builder_protocol_redis as protocol;
+extern crate habitat_builder_dbcache_redis as dbcache;
 extern crate r2d2;
 extern crate r2d2_redis;
 


### PR DESCRIPTION
This renames all the redis_lib crates with a `_redis` suffix so that the Cargo.lock file does not get duplicate crates.

Signed-off-by: Matt Wrock <matt@mattwrock.com>