### PR TITLE
migrate origins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,12 +1,14 @@
 [root]
-name = "redis-postgres-migrator"
+name = "redis_postgres_migrator"
 version = "0.1.0"
 dependencies = [
+ "habitat_builder_originsrv 0.0.0",
+ "habitat_builder_protocol 0.0.0",
  "habitat_builder_sessionsrv 0.0.0",
  "postgres_lib 0.1.0",
  "redis_extraction 0.1.0",
  "redis_lib 0.1.0",
- "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "redis-postgres-migrator"
+name = "redis_postgres_migrator"
 version = "0.1.0"
 authors = ["Nell Shamrell <nellshamrell@gmail.com>"]
 
@@ -15,10 +15,11 @@ path = "./src/redis_lib/"
 [dependencies.postgres_lib]
 path = "./src/postgres_lib/"
 
+[dependencies.habitat_builder_originsrv]
+path = "./src/postgres_lib/builder-originsrv"
+
+[dependencies.habitat_builder_protocol]
+path = "./src/postgres_lib/builder-protocol"
+
 [dependencies.habitat_builder_sessionsrv]
 path = "./src/postgres_lib/builder-sessionsrv"
-
-
-
-
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,8 @@
-use std::env;
-extern crate redis_lib;
+extern crate redis_postgres_migrator as migrator;
 extern crate postgres_lib;
-extern crate habitat_builder_sessionsrv;
-extern crate redis_extraction;
-extern crate regex;
 
-use habitat_builder_sessionsrv as session_srv;
-use regex::Regex;
+use std::env;
+use migrator::migrators;
 
 fn main() {
     let args: Vec<_> = env::args().collect();
@@ -14,156 +10,11 @@ fn main() {
 
     // We start with transferring accounts, which live in the builder_sessionsrv data store
     let sessionsrv_data_store = postgres_lib::create_sessionsrv_data_store();
-
-    redis_to_postgres(redis_address, sessionsrv_data_store);
-}
-
-pub fn redis_to_postgres(redis_addr: &str, data_store: session_srv::data_store::DataStore) {
-    let accounts = redis_extraction::extract_accounts(redis_addr);
-
-    let re = Regex::new(r":(\d+)").unwrap();
-    for x in accounts {
-        for cap in re.captures_iter(&x) {
-            let ds = data_store.clone();
-            let account_id_string = &cap[1];
-            let account_id = account_id_string.parse::<u64>();
-
-            redis_to_postgres_account(redis_addr,
-                                      ds,
-                                      account_id.unwrap())
-        }
-    }
-
-    // This is not used yet, but we will need this line
-    // when importing origins to postgres and any
-    // other items that go into originsrv
     let originsrv_data_store = postgres_lib::create_originsrv_data_store();
-}
 
-pub fn redis_to_postgres_account(redis_addr: &str,
-                                 data_store: session_srv::data_store::DataStore,
-                                 id: u64) {
-    let redis_account = redis_lib::find_account_by_id(redis_addr, id.to_string());
-    let config = session_srv::config::Config::default();
-
-    let session = postgres_lib::create_session("pretend_session".to_string(),
-                                               redis_account.get_id(),
-                                               redis_account.get_email().to_string(),
-                                               redis_account.get_name().to_string());
-
-    let account = postgres_lib::create_account(data_store, session);
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn test_redis_addr() -> &'static str {
-        "redis://127.0.0.1/"
-    }
-
-    #[test]
-    fn test_redis_account_create() {
-        let session = redis_lib::create_session(String::from("hail2theking"),
-                                                64,
-                                                String::from("bobo@chef.io"),
-                                                String::from("Bobo T. Clown"));
-
-        let account = redis_lib::create_account(test_redis_addr(), session);
-
-        let found_account = redis_lib::find_account_by_id(test_redis_addr(),
-                                                          account.get_id().to_string());
-
-        assert_eq!(account.get_id(), found_account.get_id());
-    }
-
-    #[test]
-    fn test_postgres_account_create() {
-        let ds = postgres_lib::create_test_data_store();
-        let ds1 = ds.clone();
-        let ds2 = ds.clone();
-
-        let session = postgres_lib::create_session(String::from("hail2theking"),
-                                                   64,
-                                                   String::from("bobo@chef.io"),
-                                                   String::from("Bobo T. Clown"));
-
-        let account = postgres_lib::create_account(ds1, session);
-        let found_account = postgres_lib::get_account(ds2, account.get_name()).unwrap();
-
-        assert_eq!(account.get_id(), found_account.get_id());
-    }
-
-    #[test]
-    fn test_redis_to_postgres_account1() {
-        // Create account in redis
-        let session = redis_lib::create_session(String::from("scopuli"),
-                                                64,
-                                                String::from("julie.mao@chef.io"),
-                                                String::from("Julie Mao"));
-
-
-        let redis_account = redis_lib::create_account(test_redis_addr(), session);
-
-        // Set up postgres datastore
-        let ds = postgres_lib::create_test_data_store();
-        let ds1 = ds.clone();
-        let ds2 = ds.clone();
-        let ds3 = ds.clone();
-
-        // Check that account does not exist in postgres
-        let not_found = postgres_lib::get_account(ds1, redis_account.get_name());
-        assert_eq!(not_found, None);
-
-        redis_to_postgres_account(test_redis_addr(),
-                                  ds2,
-                                  redis_account.get_id());
-
-        // check that account is now in postgres
-        let postgres_account = postgres_lib::get_account(ds3, redis_account.get_name()).unwrap();
-
-        assert_eq!(redis_account.get_name(), postgres_account.get_name());
-    }
-
-    #[test]
-    fn test_redis_to_postgres_accounts() {
-        let redis_addr = "redis://127.0.0.1/";
-        // Create account in redis
-        let session = redis_lib::create_session(String::from("scopuli"),
-                                                64,
-                                                String::from("julie.mao@chef.io"),
-                                                String::from("Julie Mao"));
-
-
-        let redis_account = redis_lib::create_account(redis_addr, session);
-
-        let session2 = redis_lib::create_session(String::from("canterbury"),
-                                                 64,
-                                                 String::from("james.holden@chef.io"),
-                                                 String::from("James Holden"));
-
-        let redis_account2 = redis_lib::create_account(redis_addr, session2);
-
-        // Set up postgres datastore
-        let ds = postgres_lib::create_test_data_store();
-
-        // Check that account does not exist in postgres
-        let not_found1 = postgres_lib::get_account(ds.clone(), redis_account.get_name());
-        let not_found2 = postgres_lib::get_account(ds.clone(), redis_account2.get_name());
-
-        assert_eq!(not_found1, None);
-        assert_eq!(not_found2, None);
-
-        // transfer account to postgres
-        redis_to_postgres(redis_addr, ds.clone());
-
-        // check that accounts are now in postgres
-        let postgres_account = postgres_lib::get_account(ds.clone(), redis_account.get_name())
-            .unwrap();
-        assert_eq!(redis_account.get_name(), postgres_account.get_name());
-
-        let postgres_account2 = postgres_lib::get_account(ds.clone(), redis_account2.get_name())
-            .unwrap();
-        assert_eq!(redis_account2.get_name(), postgres_account2.get_name());
-    }
+    migrators::account::redis_to_postgres(redis_address, sessionsrv_data_store.clone());
+    let m = migrators::origin::OriginMigrator::new(redis_address.to_string(),
+                                                   originsrv_data_store,
+                                                   sessionsrv_data_store.clone());
+    m.migrate();
 }

--- a/src/migrators/account.rs
+++ b/src/migrators/account.rs
@@ -1,0 +1,37 @@
+use redis_lib;
+use postgres_lib;
+use habitat_builder_sessionsrv as session_srv;
+use redis_extraction;
+use regex::Regex;
+
+pub fn redis_to_postgres(redis_addr: &str, data_store: session_srv::data_store::DataStore) {
+    let accounts = redis_extraction::extract_accounts(redis_addr);
+
+    let re = Regex::new(r":(\d+)").unwrap();
+    for x in accounts {
+        for cap in re.captures_iter(&x) {
+            let ds = data_store.clone();
+            let account_id_string = &cap[1];
+            let account_id = account_id_string.parse::<u64>();
+
+            println!("{:?}", cap);
+            redis_to_postgres_account(redis_addr,
+                                      ds,
+                                      account_id.unwrap())
+        }
+    }
+}
+
+pub fn redis_to_postgres_account(redis_addr: &str,
+                                 data_store: session_srv::data_store::DataStore,
+                                 id: u64) {
+    let redis_account = redis_lib::find_account_by_id(redis_addr, id.to_string());
+    let config = session_srv::config::Config::default();
+
+    let session = postgres_lib::create_session("pretend_session".to_string(),
+                                               redis_account.get_id(),
+                                               redis_account.get_email().to_string(),
+                                               redis_account.get_name().to_string());
+
+    let account = postgres_lib::create_account(data_store, session);
+}

--- a/src/migrators/mod.rs
+++ b/src/migrators/mod.rs
@@ -1,0 +1,2 @@
+pub mod origin;
+pub mod account;

--- a/src/migrators/origin.rs
+++ b/src/migrators/origin.rs
@@ -1,0 +1,53 @@
+use habitat_builder_originsrv::data_store::DataStore as originsrv_datastore;
+use habitat_builder_sessionsrv::data_store::DataStore as sessionsrv_datastore;
+use postgres_lib;
+use redis_lib;
+use redis_extraction;
+use regex::Regex;
+
+pub struct OriginMigrator {
+    redis_uri: String,
+    originsrv_store: originsrv_datastore,
+    sessionsrv_store: sessionsrv_datastore,
+}
+
+impl OriginMigrator {
+    pub fn new(redis_uri: String,
+               originsrv_store: originsrv_datastore,
+               sessionsrv_store: sessionsrv_datastore)
+               -> OriginMigrator {
+        OriginMigrator {
+            redis_uri: redis_uri,
+            originsrv_store: originsrv_store,
+            sessionsrv_store: sessionsrv_store,
+        }
+    }
+
+    pub fn migrate(&self) {
+        let origins = redis_extraction::extract_origins(self.redis_uri.as_str());
+
+        let re = Regex::new(r":(\d+)").unwrap();
+        for x in origins {
+            for cap in re.captures_iter(&x) {
+                let origin_id = &cap[1];
+
+                self.migrate_origin(origin_id.parse::<u64>().unwrap());
+            }
+        }
+    }
+
+    pub fn migrate_origin(&self, id: u64) {
+        let redis_origin = redis_lib::find_origin_by_id(self.redis_uri.as_str(), id);
+        println!("migrating origin:{}", redis_origin.get_name());
+        let redis_account = redis_lib::find_account_by_id(self.redis_uri.as_str(),
+                                                          redis_origin.get_owner_id().to_string());
+        let pg_account = postgres_lib::get_account(self.sessionsrv_store.clone(),
+                                                   redis_account.get_name())
+                .expect("no account found for origin");
+
+        postgres_lib::create_origin(self.originsrv_store.clone(),
+                                    redis_origin.get_name(),
+                                    pg_account.get_id(),
+                                    pg_account.get_name());
+    }
+}

--- a/src/redis_extraction/src/lib.rs
+++ b/src/redis_extraction/src/lib.rs
@@ -2,20 +2,24 @@ extern crate redis;
 use redis::Commands;
 
 pub fn extract_accounts(redis_addr: &str) -> Vec<String> {
-    let account_keys = account_keys(redis_addr).unwrap();
+    let account_keys = redis_keys(redis_addr, "account").expect("error extracting account keys");
     let account_data = redis::from_redis_value::<Vec<String>>(&account_keys).unwrap();
     account_data
 }
 
-pub fn account_keys(redis_addr: &str) -> redis::RedisResult<(redis::Value)> {
+pub fn redis_keys(redis_addr: &str, entity: &str) -> redis::RedisResult<(redis::Value)> {
     let client = redis_client(redis_addr);
     let con = redis::Client::get_connection(&client).unwrap();
 
-    let account_keys = con.keys("*account:*");
-    account_keys
+    con.keys(format!("*{}:*", entity))
+}
+
+pub fn extract_origins(redis_addr: &str) -> Vec<String> {
+    let origin_keys = redis_keys(redis_addr, "origin").expect("error extracting origin keys");
+    redis::from_redis_value::<Vec<String>>(&origin_keys).unwrap()
 }
 
 fn redis_client(redis_addr: &str) -> redis::Client {
-    let client = redis::Client::open("redis://127.0.0.1/");
+    let client = redis::Client::open(redis_addr);
     client.unwrap()
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,8 +1,8 @@
+extern crate redis_postgres_migrator;
 extern crate redis_lib;
 extern crate postgres_lib;
-extern crate redis_extraction;
+extern crate habitat_builder_protocol;
 extern crate habitat_builder_originsrv;
 extern crate habitat_builder_sessionsrv;
-extern crate regex;
 
-pub mod migrators;
+mod migrators;

--- a/tests/migrators/account.rs
+++ b/tests/migrators/account.rs
@@ -1,0 +1,113 @@
+use postgres_lib;
+use redis_lib;
+
+use redis_postgres_migrator::migrators;
+
+fn test_redis_addr() -> &'static str {
+    "redis://127.0.0.1/"
+}
+
+#[test]
+fn test_redis_account_create() {
+    let session = redis_lib::create_session(String::from("hail2theking"),
+                                            64,
+                                            String::from("bobo@chef.io"),
+                                            String::from("Bobo T. Clown"));
+
+    let account = redis_lib::create_account(test_redis_addr(), session);
+
+    let found_account = redis_lib::find_account_by_id(test_redis_addr(),
+                                                        account.get_id().to_string());
+
+    assert_eq!(account.get_id(), found_account.get_id());
+}
+
+#[test]
+fn test_postgres_account_create() {
+    let ds = postgres_lib::create_test_sessionsrv_data_store();
+    let ds1 = ds.clone();
+    let ds2 = ds.clone();
+
+    let session = postgres_lib::create_session(String::from("hail2theking"),
+                                                64,
+                                                String::from("bobo@chef.io"),
+                                                String::from("Bobo T. Clown"));
+
+    let account = postgres_lib::create_account(ds1, session);
+    let found_account = postgres_lib::get_account(ds2, account.get_name()).unwrap();
+
+    assert_eq!(account.get_id(), found_account.get_id());
+}
+
+#[test]
+fn test_redis_to_postgres_account1() {
+    // Create account in redis
+    let session = redis_lib::create_session(String::from("scopuli"),
+                                            64,
+                                            String::from("julie.mao@chef.io"),
+                                            String::from("Julie Mao"));
+
+
+    let redis_account = redis_lib::create_account(test_redis_addr(), session);
+
+    // Set up postgres datastore
+    let ds = postgres_lib::create_test_sessionsrv_data_store();
+    let ds1 = ds.clone();
+    let ds2 = ds.clone();
+    let ds3 = ds.clone();
+
+    // Check that account does not exist in postgres
+    let not_found = postgres_lib::get_account(ds1, redis_account.get_name());
+    assert_eq!(not_found, None);
+
+    migrators::account::redis_to_postgres_account(test_redis_addr(),
+                                ds2,
+                                redis_account.get_id());
+
+    // check that account is now in postgres
+    let postgres_account = postgres_lib::get_account(ds3, redis_account.get_name()).unwrap();
+
+    assert_eq!(redis_account.get_name(), postgres_account.get_name());
+}
+
+#[test]
+fn test_redis_to_postgres_accounts() {
+    let redis_addr = "redis://127.0.0.1/";
+    // Create account in redis
+    let session = redis_lib::create_session(String::from("scopuli"),
+                                            64,
+                                            String::from("julie.mao@chef.io"),
+                                            String::from("Julie Mao"));
+
+
+    let redis_account = redis_lib::create_account(redis_addr, session);
+
+    let session2 = redis_lib::create_session(String::from("canterbury"),
+                                                64,
+                                                String::from("james.holden@chef.io"),
+                                                String::from("James Holden"));
+
+    let redis_account2 = redis_lib::create_account(redis_addr, session2);
+
+    // Set up postgres datastore
+    let ds = postgres_lib::create_test_sessionsrv_data_store();
+
+    // Check that account does not exist in postgres
+    let not_found1 = postgres_lib::get_account(ds.clone(), redis_account.get_name());
+    let not_found2 = postgres_lib::get_account(ds.clone(), redis_account2.get_name());
+
+    assert_eq!(not_found1, None);
+    assert_eq!(not_found2, None);
+
+    // transfer account to postgres
+    migrators::account::redis_to_postgres(redis_addr, ds.clone());
+
+    // check that accounts are now in postgres
+    let postgres_account = postgres_lib::get_account(ds.clone(), redis_account.get_name())
+        .unwrap();
+    assert_eq!(redis_account.get_name(), postgres_account.get_name());
+
+    let postgres_account2 = postgres_lib::get_account(ds.clone(), redis_account2.get_name())
+        .unwrap();
+    assert_eq!(redis_account2.get_name(), postgres_account2.get_name());
+}

--- a/tests/migrators/mod.rs
+++ b/tests/migrators/mod.rs
@@ -1,0 +1,2 @@
+mod account;
+mod origin;

--- a/tests/migrators/origin.rs
+++ b/tests/migrators/origin.rs
@@ -1,0 +1,43 @@
+use habitat_builder_protocol::originsrv;
+use redis_postgres_migrator::migrators;
+use postgres_lib;
+use redis_lib;
+
+const TEST_REDIS_ADDR: &'static str = "redis://127.0.0.1/";
+
+#[test]
+fn test_migrate() {
+    let ds1 = postgres_lib::create_test_originsrv_data_store();
+    let ds2 = ds1.clone();
+    ds2.setup();
+    let sdb1 = postgres_lib::create_test_sessionsrv_data_store();
+    let sdb2 = sdb1.clone();
+
+    let redis_session = redis_lib::create_session(String::from("token"),
+                                                  64,
+                                                  String::from("bobo@chef.io"),
+                                                  String::from("owner name"));
+    let redis_account = redis_lib::create_account(TEST_REDIS_ADDR, redis_session);
+    let pg_session = postgres_lib::create_session(String::from("token"),
+                                                  redis_account.get_id(),
+                                                  redis_account.get_email().to_string(),
+                                                  redis_account.get_name().to_string());
+    let pg_account = postgres_lib::create_account(sdb1, pg_session);
+
+    let origin1 = redis_lib::create_origin(TEST_REDIS_ADDR,
+                                              "origin_name1",
+                                              redis_account.get_id());
+    let origin2 = redis_lib::create_origin(TEST_REDIS_ADDR,
+                                              "origin_name2",
+                                              redis_account.get_id());
+
+    migrators::origin::OriginMigrator::new(TEST_REDIS_ADDR.to_string(), ds1, sdb2).migrate();
+
+    let mut oar = originsrv::CheckOriginAccessRequest::new();
+    oar.set_account_id(pg_account.get_id());
+    oar.set_origin_name(origin1.get_name().to_string());
+    assert!(ds2.check_account_in_origin(&oar).unwrap());
+
+    oar.set_origin_name(origin2.get_name().to_string());
+    assert!(ds2.check_account_in_origin(&oar).unwrap());
+}


### PR DESCRIPTION
This also organizes each entity into their own module which may help us avoid merge conflicts as we move forward.

Signed-off-by: Matt Wrock <matt@mattwrock.com>