### PR TITLE
do not migrate origins if they already exist in postgres

### DIFF
--- a/src/migrators/origin.rs
+++ b/src/migrators/origin.rs
@@ -38,6 +38,12 @@ impl OriginMigrator {
 
     pub fn migrate_origin(&self, id: u64) {
         let redis_origin = redis_lib::find_origin_by_id(self.redis_uri.as_str(), id);
+        if postgres_lib::get_origin_by_name(self.originsrv_store.clone(), redis_origin.get_name())
+               .is_some() {
+            println!("Ignoring origin {}. Already migrated.",
+                     redis_origin.get_name());
+            return;
+        }
         println!("migrating origin:{}", redis_origin.get_name());
         let redis_account = redis_lib::find_account_by_id(self.redis_uri.as_str(),
                                                           redis_origin.get_owner_id().to_string());

--- a/src/postgres_lib/src/lib.rs
+++ b/src/postgres_lib/src/lib.rs
@@ -89,6 +89,14 @@ pub fn get_account(data_store: sessionsrv_data_store,
     account
 }
 
+pub fn get_origin_by_name(data_store: originsrv_data_store,
+                   origin_name: &str)
+                   -> std::option::Option<protocol::originsrv::Origin> {
+    let mut og = protocol::originsrv::OriginGet::new();
+    og.set_name(origin_name.to_string());
+    data_store.get_origin(&og).expect("cant get origin yo")
+}
+
 pub fn get_invitations_by_origin(data_store: originsrv_data_store,
                                  origin_id: u64)
                                  -> protocol::originsrv::OriginInvitationListResponse {

--- a/tests/migrators/origin.rs
+++ b/tests/migrators/origin.rs
@@ -7,11 +7,10 @@ const TEST_REDIS_ADDR: &'static str = "redis://127.0.0.1/";
 
 #[test]
 fn test_migrate_origin() {
-    let ds1 = postgres_lib::create_test_originsrv_data_store();
-    let ds2 = ds1.clone();
-    ds2.setup();
-    let sdb1 = postgres_lib::create_test_sessionsrv_data_store();
-    let sdb2 = sdb1.clone();
+    let ds = postgres_lib::create_test_originsrv_data_store();
+    ds.setup();
+    let sdb = postgres_lib::create_test_sessionsrv_data_store();
+    sdb.setup();
 
     let redis_session = redis_lib::create_session(String::from("token"),
                                                   64,
@@ -22,7 +21,7 @@ fn test_migrate_origin() {
                                                   redis_account.get_id(),
                                                   redis_account.get_email().to_string(),
                                                   redis_account.get_name().to_string());
-    let pg_account = postgres_lib::create_account(sdb1, pg_session);
+    let pg_account = postgres_lib::create_account(sdb.clone(), pg_session);
 
     let origin1 = redis_lib::create_origin(TEST_REDIS_ADDR,
                                               "origin_name1",
@@ -30,14 +29,17 @@ fn test_migrate_origin() {
     let origin2 = redis_lib::create_origin(TEST_REDIS_ADDR,
                                               "origin_name2",
                                               redis_account.get_id());
+    let origin3 = redis_lib::create_origin(TEST_REDIS_ADDR,
+                                              "origin_name2",
+                                              redis_account.get_id());
 
-    migrators::origin::OriginMigrator::new(TEST_REDIS_ADDR.to_string(), ds1, sdb2).migrate();
+    migrators::origin::OriginMigrator::new(TEST_REDIS_ADDR.to_string(), ds.clone(), sdb.clone()).migrate();
 
     let mut oar = originsrv::CheckOriginAccessRequest::new();
     oar.set_account_id(pg_account.get_id());
     oar.set_origin_name(origin1.get_name().to_string());
-    assert!(ds2.check_account_in_origin(&oar).unwrap());
+    assert!(ds.check_account_in_origin(&oar).unwrap());
 
     oar.set_origin_name(origin2.get_name().to_string());
-    assert!(ds2.check_account_in_origin(&oar).unwrap());
+    assert!(ds.check_account_in_origin(&oar).unwrap());
 }

--- a/tests/migrators/origin_key.rs
+++ b/tests/migrators/origin_key.rs
@@ -13,7 +13,7 @@ pub fn hart_file(name: &str) -> PathBuf {
 }
 
 #[test]
-fn test_migrate_origin_key() {
+fn test_migrate_public_key() {
     let ds = postgres_lib::create_test_originsrv_data_store();
     ds.setup();
 


### PR DESCRIPTION
I also changed the name of the `origin_key` test so I could isolate the origin test

Signed-off-by: Matt Wrock <matt@mattwrock.com>